### PR TITLE
fix(dictionaryindex): fix sys field dictionary index

### DIFF
--- a/src/Redis/Indexes/Builders/OneToOneIndexBuilder.php
+++ b/src/Redis/Indexes/Builders/OneToOneIndexBuilder.php
@@ -129,7 +129,7 @@ abstract class OneToOneIndexBuilder
      */
     protected function getSysField(IndexDto $dto) : string
     {
-        return $this->keys->makeSysField($dto->docId, $dto->docType);
+        return $this->keys->makeSysField($dto->docId, $dto->name);
     }
 
     /**


### PR DESCRIPTION
При индексации сущности по полю, в системном индексе хранится поле {entity_id}:{entity_name}. Если у
сущности будет несколько индесов один-к-одному то это значение перезатирается